### PR TITLE
add support for prebuild to build for all abi version of node/iojs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 npm-debug.log
 node_modules
 build
+prebuilds/

--- a/.prebuildrc
+++ b/.prebuildrc
@@ -1,0 +1,17 @@
+# abi 11
+target[] = 0.10.40
+
+# abi 14
+target[] = 0.12.7
+
+# abi 42
+target[] = 1.0.4
+
+# abi 43
+target[] = 1.8.4
+
+# abi 44
+target[] = 2.4.0
+
+# abi 45
+target[] = 3.0.0

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "WebSocket buffer utils",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Only testing builds, test have to be extraced from `ws`\" && exit 0"
+    "install": "prebuild --download",
+    "test": "echo \"Only testing builds, test have to be extraced from `ws`\" && exit 0",
+    "prebuild": "prebuild --strip"
   },
   "repository": {
     "type": "git",
@@ -21,6 +23,7 @@
   "homepage": "https://github.com/websockets/bufferutil",
   "dependencies": {
     "bindings": "1.2.x",
-    "nan": "^2.0.5"
+    "nan": "^2.0.5",
+    "prebuild": "^2.5.1"
   }
 }


### PR DESCRIPTION
In case you're interested in prebuilding `bufferutil`

![prebuild-bufferutil](https://cloud.githubusercontent.com/assets/308049/9717913/1198d3a6-5577-11e5-82f6-95824dee7e38.png)

See https://github.com/mafintosh/prebuild for more information or shoot me a question. If you stick a GitHub token in `~/.prebuildrc` that same command will also create a release on GitHub and upload the binaries to it. Later on when people do `npm install bufferutil` the prebuilt will be downloaded from there and unpacked into `build/Release` and also cache the downloaded binary in `~/.npm/_prebuilds`