### PR TITLE
Add prebuild dependency in order to cache binaries off to GitHub.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "WebSocket buffer utils",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Only testing builds, test have to be extraced from `ws`\" && exit 0"
+    "test": "echo \"Only testing builds, test have to be extraced from `ws`\" && exit 0",
+    "install": "prebuild --download",
+    "prebuild": "prebuild --verbose"
   },
   "repository": {
     "type": "git",
@@ -21,6 +23,7 @@
   "homepage": "https://github.com/websockets/bufferutil",
   "dependencies": {
     "bindings": "1.2.x",
-    "nan": "^2.0.5"
+    "nan": "^2.0.5",
+    "prebuild": "~2.3.3"
   }
 }


### PR DESCRIPTION
- Rationale: The prebuild module is a super easy way to squirrel away a binary for future use. Users often don't have the build chains in order to compile the bindings. It would be splendid if people with write access to your project would do this. Of course, prebuild would default to the same system you have right now if no binaries exist. You can override as well. Either way, this would help!
