### PR TITLE
Use aligned 64bit mask to improve performance

### DIFF
--- a/src/bufferutil.cc
+++ b/src/bufferutil.cc
@@ -75,7 +75,7 @@ protected:
 
     /* Alignment preamble */
     size_t index;
-    for (index = 0; index < length && (reinterpret_cast<size_t>(from) & 0x07); ++index)
+    for (index = 0; index < length && (reinterpret_cast<size_t>(from) & 0x07); index++)
         *from++ ^= mask[index % 4];
     length -= index;
     if (!length)
@@ -120,7 +120,7 @@ protected:
 
     /* Alignment preamble */
     size_t index;
-    for (index = 0; index < length && (reinterpret_cast<size_t>(from) & 0x07); ++index)
+    for (index = 0; index < length && (reinterpret_cast<size_t>(from) & 0x07); index++)
         *to++ ^= mask[index % 4];
     length -= index;
     if (!length)


### PR DESCRIPTION
This almost doubles mask and unmask performance on 64bit hardware. The alignment fix means the workaround for #1 can be dropped so 32 bit performance improves slightly too.

This is based on https://bug-79880-attachments.webkit.org/attachment.cgi?id=130519