### PR TITLE
Link to libc++ on macOS

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,12 @@
     {
       'target_name': 'bufferutil',
       'include_dirs': ["<!(node -e \"require('nan')\")"],
-      'sources': [ 'src/bufferutil.cc' ]
+      'sources': [ 'src/bufferutil.cc' ],
+      'xcode_settings': {
+        'MACOSX_DEPLOYMENT_TARGET': '10.8',
+        'CLANG_CXX_LANGUAGE_STANDARD': 'c++11',
+        'CLANG_CXX_LIBRARY': 'libc++'
+      }
     }
   ]
 }


### PR DESCRIPTION
This should fix #53 by overriding the std c++ library. It also works when using a node binary that links to libstdc++. `node-mapnik`, for example, does the same [thing](https://github.com/mapnik/node-mapnik/blob/b277f6580876adf6e0a7f579627efe1e082a54e9/binding.gyp#L117-L119).
