### PR TITLE
Remove bindings dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 try {
-  module.exports = require('bindings')('bufferutil');
+  module.exports = require('./build/Release/bufferutil');
 } catch (e) {
   module.exports = require('./fallback');
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "homepage": "https://github.com/websockets/bufferutil",
   "dependencies": {
-    "bindings": "1.2.x",
     "nan": "2.4.x"
   }
 }


### PR DESCRIPTION
`bufferutil` does not have a debug build or other configurations which complicate the loading of the compiled module so I think it is makes sense to remove the `bindings` dependency.