### PR TITLE
Fix masking done in Mask alignment preamble

### DIFF
--- a/src/bufferutil.cc
+++ b/src/bufferutil.cc
@@ -121,7 +121,7 @@ protected:
     /* Alignment preamble */
     size_t index;
     for (index = 0; index < length && (reinterpret_cast<size_t>(from) & 0x07); index++)
-        *to++ ^= mask[index % 4];
+        *to++ = *from++ ^ mask[index % 4];
     length -= index;
     if (!length)
         return;


### PR DESCRIPTION
The masking XOR operations done in the alignment preamble of Mask function do not actually calculate the proper masked data.

In practice the `from` buffer seems to be aligned which is probably why this has not been caught before.