### PR TITLE
Remove `merge()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,29 +20,7 @@ key.
 
 ## API
 
-The module exports 3 different functions.
-
-### `bufferUtil.merge(target, list)`
-
-Merges an array of buffers into a target buffer.
-
-#### Arguments
-
-- `target` - The target buffer.
-- `list` - An array containing the `Buffer` instances to merge.
-
-#### Example
-
-```js
-'use strict';
-
-const bufferUtil = require('bufferutil');
-const crypto = require('crypto');
-
-const target = Buffer.allocUnsafe(10);
-
-bufferUtil.merge(target, [crypto.randomBytes(5), crypto.randomBytes(5)]);
-```
+The module exports two functions.
 
 ### `bufferUtil.mask(source, mask, output, offset, length)`
 

--- a/fallback.js
+++ b/fallback.js
@@ -7,22 +7,6 @@
 'use strict';
 
 /**
- * Merges an array of buffers into a target buffer.
- *
- * @param {Buffer} target The target buffer
- * @param {Buffer[]} buffers The array of buffers to merge
- * @public
- */
-const merge = (target, buffers) => {
-  var offset = 0;
-  for (var i = 0; i < buffers.length; i++) {
-    const buf = buffers[i];
-    buf.copy(target, offset);
-    offset += buf.length;
-  }
-};
-
-/**
  * Masks a buffer using the given mask.
  *
  * @param {Buffer} source The buffer to mask
@@ -53,4 +37,4 @@ const unmask = (buffer, mask) => {
   }
 };
 
-module.exports = { merge, mask, unmask };
+module.exports = { mask, unmask };

--- a/src/bufferutil.cc
+++ b/src/bufferutil.cc
@@ -6,20 +6,6 @@
 
 #include <nan.h>
 
-NAN_METHOD(merge) {
-  char* target = node::Buffer::Data(info[0]);
-  v8::Local<v8::Array> list = info[1].As<v8::Array>();
-  uint32_t size = list->Length();
-  size_t offset = 0;
-
-  for (uint32_t i = 0; i < size; i++) {
-    v8::Local<v8::Value> source = list->Get(i);
-    size_t length = node::Buffer::Length(source);
-    memcpy(target + offset, node::Buffer::Data(source), length);
-    offset += length;
-  }
-}
-
 NAN_METHOD(mask) {
   char* from = node::Buffer::Data(info[0]);
   char* mask = node::Buffer::Data(info[1]);
@@ -120,7 +106,6 @@ NAN_METHOD(unmask) {
 }
 
 NAN_MODULE_INIT(init) {
-  NAN_EXPORT(target, merge);
   NAN_EXPORT(target, mask);
   NAN_EXPORT(target, unmask);
 }


### PR DESCRIPTION
The `merge()` function is no longer used in `ws`. It has been replaced with `Buffer.concat()` in version 1.1.0.

The function has the same functionality and performance of `Buffer.concat()` so I see no reason to keep using and maintaining it.