### PR TITLE
Port to N-API

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,13 +2,15 @@
   'targets': [
     {
       'target_name': 'bufferutil',
-      'include_dirs': ["<!(node -e \"require('nan')\")"],
-      'sources': [ 'src/bufferutil.cc' ],
-      'xcode_settings': {
-        'MACOSX_DEPLOYMENT_TARGET': '10.8',
+      'xcode_settings': { 
+        'CLANG_CXX_LIBRARY': 'libc++',
         'CLANG_CXX_LANGUAGE_STANDARD': 'c++11',
-        'CLANG_CXX_LIBRARY': 'libc++'
-      }
+        'MACOSX_DEPLOYMENT_TARGET': '10.8'
+      },
+      'include_dirs': ['<!@(node -p "require(\'node-addon-api\').include")'],
+      'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
+      'defines': ['NAPI_DISABLE_CPP_EXCEPTIONS'],
+      'sources': [ 'src/bufferutil.cc' ]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "homepage": "https://github.com/websockets/bufferutil",
   "dependencies": {
+    "node-addon-api": "~1.1.0",
     "bindings": "~1.3.0",
-    "nan": "~2.8.0",
     "prebuild-install": "~2.3.0"
   },
   "devDependencies": {

--- a/src/bufferutil.cc
+++ b/src/bufferutil.cc
@@ -4,13 +4,14 @@
  * MIT Licensed
  */
 
-#include <nan.h>
+#include <napi.h>
 
-NAN_METHOD(mask) {
-  char* from = node::Buffer::Data(info[0]);
-  char* mask = node::Buffer::Data(info[1]);
-  char* to = node::Buffer::Data(info[2]) + info[3]->Int32Value();
-  size_t length = info[4]->Int32Value();
+static void mask(const Napi::CallbackInfo& info) {
+  char* from = info[0].As<Napi::Buffer<char>>().Data();
+  char* mask = info[1].As<Napi::Buffer<char>>().Data();
+  char* to = info[2].As<Napi::Buffer<char>>().Data()
+           + info[3].As<Napi::Number>().Int32Value();
+  size_t length = info[4].As<Napi::Number>().Int32Value();
   size_t index = 0;
 
   //
@@ -57,10 +58,10 @@ NAN_METHOD(mask) {
   }
 }
 
-NAN_METHOD(unmask) {
-  char* from = node::Buffer::Data(info[0]);
-  size_t length = node::Buffer::Length(info[0]);
-  char* mask = node::Buffer::Data(info[1]);
+static void unmask(const Napi::CallbackInfo& info) {
+  char* from = info[0].As<Napi::Buffer<char>>().Data();
+  size_t length = info[0].As<Napi::Buffer<char>>().Length();
+  char* mask = info[1].As<Napi::Buffer<char>>().Data();
   size_t index = 0;
 
   //
@@ -105,9 +106,10 @@ NAN_METHOD(unmask) {
   }
 }
 
-NAN_MODULE_INIT(init) {
-  NAN_EXPORT(target, mask);
-  NAN_EXPORT(target, unmask);
+static Napi::Object init(Napi::Env env, Napi::Object exports) {
+  exports.Set("mask", Napi::Function::New(env, &mask));
+  exports.Set("unmask", Napi::Function::New(env, &unmask));
+  return exports;
 }
 
-NODE_MODULE(bufferutil, init)
+NODE_API_MODULE(bufferutil, init)


### PR DESCRIPTION
- removed nan dependency
- add node-addon-api dependency
- port bufferutil.cc to N-API

Since node 8 there is a new experimental feature called N-API which is aimed at reducing maintenance cost for node native addons. Checkout this [blog](https://medium.com/the-node-js-collection/n-api-next-generation-node-js-apis-for-native-modules-169af5235b06)/[talk](https://www.youtube.com/watch?v=E848bgHfoxE) for more details on its benefits.

bufferutil is one of the top 35 native modules by dependency count. I used this native module first as playground to get my hands on N-API. The port to N-API is now working pretty good so I like to share this code. This should not be merged into master. N-API is still a experimental feature. It would be useful to have a napi branch. The [work group](https://github.com/nodejs/abi-stable-node) is asking for feedback from productive running systems. It would be nice if this branch could be published to npm registry. [Here](https://nodejs.org/en/docs/guides/publishing-napi-modules/) is a guide on how to do that. But its up to you if you want to support this feature in experimental state.