### PR TITLE
Don't force architecture

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -15,16 +15,7 @@
           },
           'xcode_settings': {
             'MACOSX_DEPLOYMENT_TARGET': '10.7'
-          },
-          'conditions': [
-            # Use Perl v-strings to compare versions.
-            ['clang_version and <!(perl -e \'print <(clang_version) cmp 12.0.0\')==1', {
-              'xcode_settings': {
-                'OTHER_CFLAGS': ['-arch arm64'],
-                'OTHER_LDFLAGS': ['-arch arm64']
-              }
-            }]
-          ]
+          }
         }]
       ]
     }


### PR DESCRIPTION
Forcing a specific architecture depending on the clang_version seems wrong - and resulted in incorrect builds for us, since we did actually want to build `x64` from ARM64 machines.