### PR TITLE
feat: Don't load native module if WS_NO_BUFFER_UTIL is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 'use strict';
 
 try {
+  if (process.env.WS_NO_BUFFER_UTIL) {
+    throw new Error('WS_NO_BUFFER_UTIL is set');
+  }
+  
   module.exports = require('node-gyp-build')(__dirname);
 } catch (e) {
   module.exports = require('./fallback');


### PR DESCRIPTION
This PR ensures that `bufferutil.node` is not loaded if the environment variable `WS_NO_BUFFER_UTIL` is set.

I'm in a somewhat weird situation: I want to build an app that needs to rebuild `bufferutil` in `node_modules`. At the same time, some of my `devDependencies` use `webSockets`, so they end up loading `bufferutil.node` - which creates a file lock on Windows, and then an `EPERM` error when I end up calling `node-gyp rebuild`. With this change, I can ensure that my various dependencies don't load `bufferutil` even if it's present - and even if I can't directly control which exact version of `webSockets` they use.