### PR TITLE
[perf] Do not make compiler life harder

### DIFF
--- a/src/bufferutil.c
+++ b/src/bufferutil.c
@@ -59,24 +59,20 @@ napi_value Mask(napi_env env, napi_callback_info info) {
   // Apply 64 bit mask in 8 byte chunks.
   //
   uint32_t loop = length / 8;
-  uint64_t *pMask8 = (uint64_t *)maskAlignedArray;
-
-  while (loop--) {
-    uint64_t *pFrom8 = (uint64_t *)source;
-    uint64_t *pTo8 = (uint64_t *)destination;
-    *pTo8 = *pFrom8 ^ *pMask8;
-    source += 8;
-    destination += 8;
-  }
+  uint64_t mask8 = ((uint64_t *)maskAlignedArray)[0];
+  uint64_t *pFrom8 = (uint64_t *)source;
+  uint64_t *pTo8 = (uint64_t *)destination;
+  for (uint32_t i = 0; i < loop; i++) pTo8[i] = pFrom8[i] ^ mask8;
+  source += 8 * loop;
+  destination += 8 * loop;
 
   //
   // Apply mask to remaining data.
   //
-  uint8_t *pmaskAlignedArray = maskAlignedArray;
 
   length %= 8;
-  while (length--) {
-    *destination++ = *source++ ^ *pmaskAlignedArray++;
+  for (uint32_t i = 0; i < length; i++) {
+    destination[i] = source[i] ^ maskAlignedArray[i];
   }
 
   return NULL;
@@ -91,8 +87,8 @@ napi_value Unmask(napi_env env, napi_callback_info info) {
   assert(status == napi_ok);
 
   uint8_t *source;
-  size_t length;
   uint8_t *mask;
+  size_t length;
 
   status = napi_get_buffer_info(env, argv[0], (void **)&source, &length);
   assert(status == napi_ok);
@@ -127,22 +123,19 @@ napi_value Unmask(napi_env env, napi_callback_info info) {
   // Apply 64 bit mask in 8 byte chunks.
   //
   uint32_t loop = length / 8;
-  uint64_t *pMask8 = (uint64_t *)maskAlignedArray;
+  uint64_t mask8 = ((uint64_t *)maskAlignedArray)[0];
 
-  while (loop--) {
-    uint64_t *pSource8 = (uint64_t *)source;
-    *pSource8 ^= *pMask8;
-    source += 8;
-  }
+  uint64_t *pSource8 = (uint64_t *)source;
+  for (uint32_t i = 0; i < loop; i++) pSource8[i] ^= mask8;
+  source += 8 * loop;
 
   //
   // Apply mask to remaining data.
   //
-  uint8_t *pmaskAlignedArray = maskAlignedArray;
 
   length %= 8;
-  while (length--) {
-    *source++ ^= *pmaskAlignedArray++;
+  for (uint32_t i = 0; i < length; i++) {
+    source[i] ^= maskAlignedArray[i];
   }
 
   return NULL;

--- a/src/bufferutil.c
+++ b/src/bufferutil.c
@@ -62,15 +62,18 @@ napi_value Mask(napi_env env, napi_callback_info info) {
   uint64_t mask8 = ((uint64_t *)maskAlignedArray)[0];
   uint64_t *pFrom8 = (uint64_t *)source;
   uint64_t *pTo8 = (uint64_t *)destination;
-  for (uint32_t i = 0; i < loop; i++) pTo8[i] = pFrom8[i] ^ mask8;
-  source += 8 * loop;
-  destination += 8 * loop;
+
+  for (uint32_t i = 0; i < loop; i++) {
+    pTo8[i] = pFrom8[i] ^ mask8;
+  }
 
   //
   // Apply mask to remaining data.
   //
-
   length %= 8;
+  source += 8 * loop;
+  destination += 8 * loop;
+
   for (uint32_t i = 0; i < length; i++) {
     destination[i] = source[i] ^ maskAlignedArray[i];
   }
@@ -124,16 +127,18 @@ napi_value Unmask(napi_env env, napi_callback_info info) {
   //
   uint32_t loop = length / 8;
   uint64_t mask8 = ((uint64_t *)maskAlignedArray)[0];
-
   uint64_t *pSource8 = (uint64_t *)source;
-  for (uint32_t i = 0; i < loop; i++) pSource8[i] ^= mask8;
-  source += 8 * loop;
+
+  for (uint32_t i = 0; i < loop; i++) {
+    pSource8[i] ^= mask8;
+  }
 
   //
   // Apply mask to remaining data.
   //
-
   length %= 8;
+  source += 8 * loop;
+
   for (uint32_t i = 0; i < length; i++) {
     source[i] ^= maskAlignedArray[i];
   }


### PR DESCRIPTION
Loops with bodies not depending on previous iterations are easier

Tested on M3 (please recheck on other platforms)

Before:
```
{ size: 10 }
unmask x 25,000,000 ops/sec @ 40ns/op (0ns..185μs)
unmask x 24,390,244 ops/sec @ 41ns/op (0ns..16ms)
mask x 18,518,519 ops/sec @ 54ns/op (0ns..1353μs)
mask x 18,181,818 ops/sec @ 55ns/op (0ns..5ms)
{ size: 128 }
unmask x 19,607,843 ops/sec @ 51ns/op (0ns..195μs)
unmask x 19,607,843 ops/sec @ 51ns/op (0ns..545μs)
mask x 16,949,153 ops/sec @ 59ns/op (0ns..77μs)
mask x 16,949,153 ops/sec @ 59ns/op (0ns..1437μs)
{ size: 1024 }
unmask x 5,988,024 ops/sec @ 167ns/op (41ns..8ms)
unmask x 6,024,096 ops/sec @ 166ns/op (83ns..15ms)
mask x 9,090,909 ops/sec @ 110ns/op (0ns..64μs)
mask x 9,174,312 ops/sec @ 109ns/op (41ns..835μs)
{ size: 10239 }
unmask x 750,751 ops/sec @ 1332ns/op (417ns..147μs)
unmask x 747,384 ops/sec @ 1338ns/op (417ns..144μs)
mask x 1,727,116 ops/sec @ 579ns/op (459ns..63μs)
mask x 1,730,104 ops/sec @ 578ns/op (500ns..70μs)
{ size: 1048576 }
unmask x 7,260 ops/sec @ 137μs/op (124μs..217μs)
unmask x 7,096 ops/sec @ 140μs/op (124μs..820μs)
mask x 16,944 ops/sec @ 59μs/op (55μs..1298μs)
mask x 17,160 ops/sec @ 58μs/op (55μs..226μs)
```

After
```
{ size: 10 }
unmask x 25,641,026 ops/sec @ 39ns/op (0ns..77μs)
unmask x 25,000,000 ops/sec @ 40ns/op (0ns..3ms)
mask x 19,607,843 ops/sec @ 51ns/op (0ns..819μs)
mask x 19,230,769 ops/sec @ 52ns/op (0ns..212μs)
{ size: 128 }
unmask x 23,809,524 ops/sec @ 42ns/op (0ns..137μs)
unmask x 23,809,524 ops/sec @ 42ns/op (0ns..56μs)
mask x 19,230,769 ops/sec @ 52ns/op (0ns..87μs)
mask x 19,230,769 ops/sec @ 52ns/op (0ns..68μs)
{ size: 1024 }
unmask x 19,607,843 ops/sec @ 51ns/op (0ns..60μs)
unmask x 20,000,000 ops/sec @ 50ns/op (0ns..97μs)
mask x 16,129,032 ops/sec @ 62ns/op (0ns..54μs)
mask x 16,129,032 ops/sec @ 62ns/op (0ns..656μs)
{ size: 10239 }
unmask x 6,410,256 ops/sec @ 156ns/op (83ns..493μs)
unmask x 6,535,948 ops/sec @ 153ns/op (42ns..105μs)
mask x 6,329,114 ops/sec @ 158ns/op (83ns..63μs)
mask x 6,329,114 ops/sec @ 158ns/op (42ns..72μs)
{ size: 1048576 }
unmask x 60,831 ops/sec @ 16μs/op (16μs..97μs)
unmask x 61,058 ops/sec @ 16μs/op (16μs..132μs)
mask x 70,817 ops/sec @ 14μs/op (12μs..104μs)
mask x 62,224 ops/sec @ 16μs/op (12μs..98μs)
```

Has to be retested on smth else